### PR TITLE
Make <select> legible in Windows dark mode

### DIFF
--- a/app/assets/stylesheets/css-zero/reset.css
+++ b/app/assets/stylesheets/css-zero/reset.css
@@ -220,7 +220,6 @@ video {
 /*
   1. Inherit font styles in all browsers.
   2. Remove border radius in all browsers.
-  3. Remove background color in all browsers.
   4. Ensure consistent opacity for disabled states in all browsers.
 */
 
@@ -236,8 +235,18 @@ textarea,
   letter-spacing: inherit; /* 1 */
   color: inherit; /* 1 */
   border-radius: 0; /* 2 */
-  background-color: transparent; /* 3 */
-  opacity: 1; /* 4 */
+  opacity: 1; /* 3 */
+}
+
+/*
+  Remove background color in all browsers.
+*/
+button,
+input,
+optgroup,
+textarea,
+::file-selector-button {
+  background-color: transparent;
 }
 
 /*


### PR DESCRIPTION
In Windows, in dark mode (on Chrome), `background-color: transparent` for a `<select>` makes the dropdown background (fully opaque) white. Since the text is white too, it's unreadable.

I wasn't sure what the best way to fix it was:

* Simply remove `background-color: transparent` altogether?
* Add special dark mode handling (confirmed that this fixes it)?
  ```css
  @media (prefers-color-scheme: dark) {
    select {
      background-color: rgba(0, 0, 0, 1);
    }
  }
  ```

In the end, I chose to keep it as close as possible to what's already there, and made a new style that doesn't apply it to the `select`.