### PR TITLE
Add missing circle-alert and circle-check icons for the alert component

### DIFF
--- a/lib/generators/css_zero/add/resources.yml
+++ b/lib/generators/css_zero/add/resources.yml
@@ -3,6 +3,8 @@ accordion:
   - app/assets/images/chevron-down.svg
 alert:
   - app/assets/stylesheets/alert.css
+  - app/assets/images/circle-alert.svg
+  - app/assets/images/circle-check.svg
 autoanimate:
   - app/assets/stylesheets/autoanimate.css
 autosave:
@@ -90,6 +92,8 @@ icons:
   - app/assets/images/minus.svg
   - app/assets/images/sun.svg
   - app/assets/images/moon.svg
+  - app/assets/images/circle-alert.svg
+  - app/assets/images/circle-check.svg
 input:
   - app/assets/stylesheets/input.css
   - app/assets/images/chevron-down-zinc-500.svg

--- a/lib/generators/css_zero/add/templates/app/assets/images/circle-alert.svg
+++ b/lib/generators/css_zero/add/templates/app/assets/images/circle-alert.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-alert-icon lucide-circle-alert"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>

--- a/lib/generators/css_zero/add/templates/app/assets/images/circle-check.svg
+++ b/lib/generators/css_zero/add/templates/app/assets/images/circle-check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-icon lucide-circle-check"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>

--- a/lib/generators/css_zero/add/templates/app/assets/stylesheets/icons.css
+++ b/lib/generators/css_zero/add/templates/app/assets/stylesheets/icons.css
@@ -39,3 +39,5 @@ img.icon {
 .icon--minus { --svg: url("minus.svg"); }
 .icon--sun { --svg: url("sun.svg"); }
 .icon--moon { --svg: url("moon.svg"); }
+.icon--circle-alert { --svg: url("circle-alert.svg"); }
+.icon--circle-check { --svg: url("circle-check.svg"); }


### PR DESCRIPTION
This adds the missing `circle-alert` and `circle-check` icons from lucide.dev for the `alert` component.