### PR TITLE
Fix add resources

### DIFF
--- a/lib/generators/css_zero/add/resources.yml
+++ b/lib/generators/css_zero/add/resources.yml
@@ -83,7 +83,6 @@ icons:
   - app/assets/images/chevron-right.svg
   - app/assets/images/ellipsis.svg
   - app/assets/images/chevrons-up-down.svg
-  - app/assets/images/menu.svg
   - app/assets/images/x.svg
   - app/assets/images/search.svg
   - app/assets/images/eye.svg

--- a/lib/generators/css_zero/add/resources.yml
+++ b/lib/generators/css_zero/add/resources.yml
@@ -135,7 +135,7 @@ prose:
   - app/assets/stylesheets/prose.css
 resizable:
   - app/assets/stylesheets/resizable.css
-  - app/assets/stylesheets/resizable_controller.js
+  - app/javascript/controllers/resizable_controller.js
   - app/assets/images/grip-horizontal-zink-500.svg
   - app/assets/images/grip-vertical-zink-500.svg
 separator:


### PR DESCRIPTION
The _add/resources.yml_ had a few mistakes:

1. _menu.svg_ was referenced but was previously removed
2. the path to _resizable_controller.js_ was accidentally looked for in the stylesheets path
